### PR TITLE
upgrading regular upgradeable transpiler to use fast-node-lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/upgrade-safe-transpiler",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/upgrade-safe-transpiler",
-      "version": "0.3.19",
+      "version": "0.3.20",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0",
@@ -14,7 +14,7 @@
         "lodash": "^4.17.20",
         "minimatch": "^5.0.0",
         "minimist": "^1.2.5",
-        "solidity-ast": "^0.4.13"
+        "solidity-ast": "GeniusVentures/solidity-ast#fast-node-lookup"
       },
       "bin": {
         "upgrade-safe-transpiler": "dist/cli.js"
@@ -6009,8 +6009,8 @@
     },
     "node_modules/solidity-ast": {
       "version": "0.4.40",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.40.tgz",
-      "integrity": "sha512-M8uLBT2jgFB7B0iVAC5a2l71J8vim7aEm03AZkaHbDqyrl1pE+i5PriMEw6WlwGfHp3/Ym7cn9BqvVLQgRk+Yw=="
+      "resolved": "git+ssh://git@github.com/GeniusVentures/solidity-ast.git#59cf3db0c88f59d7772ed225f2c015eae1742d50",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -11104,9 +11104,8 @@
       }
     },
     "solidity-ast": {
-      "version": "0.4.40",
-      "resolved": "https://registry.npmjs.org/solidity-ast/-/solidity-ast-0.4.40.tgz",
-      "integrity": "sha512-M8uLBT2jgFB7B0iVAC5a2l71J8vim7aEm03AZkaHbDqyrl1pE+i5PriMEw6WlwGfHp3/Ym7cn9BqvVLQgRk+Yw=="
+      "version": "git+ssh://git@github.com/GeniusVentures/solidity-ast.git#59cf3db0c88f59d7772ed225f2c015eae1742d50",
+      "from": "solidity-ast@GeniusVentures/solidity-ast#fast-node-lookup"
     },
     "source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/upgrade-safe-transpiler",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Solidity preprocessor used to generate OpenZeppelin Contracts Upgrade Safe.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -42,7 +42,7 @@
     "lodash": "^4.17.20",
     "minimatch": "^5.0.0",
     "minimist": "^1.2.5",
-    "solidity-ast": "^0.4.13"
+    "solidity-ast": "GeniusVentures/solidity-ast#fast-node-lookup"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.165",


### PR DESCRIPTION
Once the solidity-ast is upgraded, you can change the package.json file to include the new version.

This reduces the transpile times from around 15 seconds to about 2 seconds and helps with transpiling to EIP-2535 smart contracts, which is on your roadmap for 5.0.